### PR TITLE
fix: Clean up and add SRI article to content list

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,33 +189,25 @@
     <h2 class="section-title">CONTENT</h2>
     <h3>Talks</h3>
     <dl>
-      
       <dd>Covering your bases with IP Indemnity (USA) · Deep Dive: AI Webinar Series        <a href="https://opensource.org/ai/webinars/covering-your-bases-with-ip-indemnity">Watch</a></dd>
       
       <dd>Open Source 101 · Keynote (USA) <a href="https://www.youtube.com/watch?v=xaO1jXzDTlY">Watch</a></dd>
-
       
       <dd>Kubernetes Community Days Guatemala · Keynote (Guatemala) <a href="https://youtu.be/Rs8-kAI1SRA?t=2499">Watch</a></dd>
 
-      
       <dd>What Keeps me up at Night · js.la (Los Angeles, CA) <a href="https://www.youtube.com/watch?v=KTQVBXb0uPM">Watch</a></dd>
-
       
       <dd>Let's talk about SRI · js.la (Santa Monica, CA) <a href="https://www.youtube.com/watch?v=ldk3-dEafVY">Watch</a></dd>
-
       
       <dd>DevRel Summit (Seattle, WA) <a href="https://speakerdeck.com/jdorfman/communicating-with-developers-in-the-21st-century">View</a></dd>
-
       
       <dd>Open source is people · All Things Open (Raleigh, NC) <a href="https://speakerdeck.com/jdorfman/open-source-is-people">View</a></dd>
-
       
       <dd>OSCON (Austin, TX) <a href="https://www.youtube.com/watch?v=6jiIeTwDKhs">Watch</a></dd>
     </dl>
 
     <h3>Podcasts</h3>
     <dl>
-      
       <dd>Sustain (podcast.sustainoss.org) <a href="https://podcast.sustainoss.org/hosts/justin-dorfman">Listen</a></dd>
       
       <dd>Approaching mistakes and contributing to open source (juniortosenior.io) <a href="https://juniortosenior.io/64">Listen</a></dd>
@@ -230,8 +222,8 @@
     </dl>
 
     <h3>Articles</h3>
-    <dl>
-      
+    
+    <dl>  
       <dd>Migrating from Monaco Editor to CodeMirror (sourcegraph.com/blog) <a href="https://sourcegraph.com/blog/migrating-monaco-codemirror">Read</a></dd>
       
       <dd>No Secrets! Quickly find sensitive files in your GitHub repo (sourcegraph.com/blog) <a href="https://sourcegraph.com/blog/no-more-secrets">Read</a></dd>
@@ -241,9 +233,10 @@
       <dd>That time I blew off Tim Berners-Lee (dev.to) <a href="https://dev.to/jdorfman/that-time-i-blew-off-tim-berners-lee-1hja">Read</a></dd>
 
       <dd>Umpires of open source licenses (opensource.com) <a href="https://opensource.com/article/19/2/umpires-open-source-licenses">Read</a></dd>
+      
+      <dd>How to implement SRI in your build process (hacks.mozilla.org) <a href="https://hacks.mozilla.org/2016/04/how-to-implement-sri-into-your-build-process/">Read</a></dd>
 
       <dd>CDN vs. S3 (posthaven.com) <a href="https://jdorfman.posthaven.com/medium-bitcoin-660x493-dot-jpg-cdn-vs-s3">Read</a></dd>
-
     </dl>
   </div>
 


### PR DESCRIPTION
This commit addresses minor formatting inconsistencies in the content list on the homepage and adds a missing article link.

- Removed extra blank lines and spacing within the Talks, Podcasts, and Articles sections for better readability.
- Added a link to the "How to implement SRI in your build process" article from hacks.mozilla.org.