### PR TITLE
Update page title and meta tags for DevRel focus

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>JUSTIN DORFMAN - Open Source Sustainer & Community Manager</title>
-  <meta name="description" content="Justin Dorfman: Sourcegraph's Open Source Community Manager, SustainOSS co-founder, and OSS contributor to Bootstrap, Font Awesome, jQuery, and more.">
-  <meta name="keywords" content="Justin Dorfman, Open Source, Sourcegraph, SustainOSS, Community Manager, Open Source Collective">
-  <meta property="og:title" content="Justin Dorfman - Open Source Sustainer & Community Manager">
-  <meta property="og:description" content="Sourcegraph's Open Source Community Manager, SustainOSS co-founder, OSS contributor and advocate.">
+  <title>Justin Dorfman | DevRel & Video Strategist</title>
+  <meta name="description" content="Helping developers ship faster through storytelling and high-impact video content. DevRel and video strategy by Justin Dorfman.">
+  <meta name="keywords" content="Justin Dorfman, Developer Relations, DevRel, Video Strategy, Developer Content, Sourcegraph, Developer Storytelling">
+  <meta property="og:title" content="Justin Dorfman | DevRel & Video Strategist">
+  <meta property="og:description" content="Helping developers ship faster through storytelling and high-impact video content.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://www.justindorfman.com">
   <meta name="twitter:card" content="summary">


### PR DESCRIPTION
## Summary

- Update page title from "Open Source Sustainer & Community Manager" to "DevRel & Video Strategist"
- Update meta description to highlight the value prop: helping developers ship faster through storytelling
- Update keywords to reflect DevRel and video strategy focus
- Update Open Graph tags for consistent social sharing

## Test plan

- [x] Verify title displays correctly in browser tab
- [ ] Test social sharing preview (Twitter/LinkedIn) shows updated metadata