### PR TITLE
chore: add wrangler config for Cloudflare Pages

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "jdorfman-www",
+  "compatibility_date": "2026-01-30",
+  "assets": {
+    "directory": "./"
+  }
+}


### PR DESCRIPTION
## Summary
Adds Cloudflare Pages configuration to fix deployment errors.

## Changes
- Added `wrangler.jsonc` to configure static asset deployment from the root directory
- Fixes the "Missing entry-point to Worker script or to assets directory" error during Cloudflare Pages builds