### PR TITLE
chore: rename wrangler project to www

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,5 +1,5 @@
 {
-  "name": "jdorfman-www",
+  "name": "www",
   "compatibility_date": "2026-01-30",
   "assets": {
     "directory": "./"


### PR DESCRIPTION
## Summary
Simplify the Cloudflare Pages project name in the wrangler configuration.

## Changes
- Rename project from `jdorfman-www` to `www` in wrangler.jsonc