### PR TITLE
feat: add new video and document Cloudflare deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Automatically adds a new YouTube video to the portfolio with proper rotation.
 
 **Skill location:** `.cursor/skills/add-video/SKILL.md`
 
+## Deployment
+
+This site is deployed on [Cloudflare Pages](https://pages.cloudflare.com/). The `wrangler.jsonc` file configures the deployment settings for Cloudflare's Wrangler CLI.
+
 ## Local Development
 
 ```bash
@@ -57,7 +61,7 @@ npx live-server
 ```
 ├── index.html                      # Main portfolio page
 ├── man.html                        # Man page style resume
-├── CNAME                           # Custom domain configuration
+├── wrangler.jsonc                  # Cloudflare Pages deployment config
 ├── AGENTS.md                       # AI agent instructions
 └── .cursor/
     └── skills/

--- a/index.html
+++ b/index.html
@@ -476,6 +476,24 @@
           <article class="video-card video-card-horizontal">
             <div class="video-thumbnail video-thumbnail-16-9">
               <iframe 
+                src="https://www.youtube.com/embed/_OyUNs258mE" 
+                title="Why GitHub Code Search Fails at Enterprise Scale"
+                frameborder="0" 
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+                allowfullscreen
+                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+              </iframe>
+            </div>
+            <div class="video-info">
+              <span class="video-category">Deep Dives / Demos</span>
+              <h3 class="video-card-title">Why GitHub Code Search Fails at Enterprise Scale</h3>
+            </div>
+          </article>
+
+          <!-- Horizontal Video Card 2 -->
+          <article class="video-card video-card-horizontal">
+            <div class="video-thumbnail video-thumbnail-16-9">
+              <iframe 
                 src="https://www.youtube.com/embed/PaoF-qnI2HE" 
                 title="GitHub Code Search vs Sourcegraph - Quick Comparison 2026"
                 frameborder="0" 
@@ -490,12 +508,12 @@
             </div>
           </article>
 
-          <!-- Horizontal Video Card 2 -->
-          <article class="video-card video-card-horizontal">
+          <!-- Small Video Card 1 -->
+          <article class="video-card video-card-small">
             <div class="video-thumbnail video-thumbnail-16-9">
               <iframe 
                 src="https://www.youtube.com/embed/yeNZ-hIicgI" 
-                title="Product Deep Dive: Feature Walkthrough"
+                title="Sourcegraph Deep Search for Slack: Query Your Codebase with Natural Language"
                 frameborder="0" 
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
                 allowfullscreen
@@ -508,12 +526,12 @@
             </div>
           </article>
 
-          <!-- Small Video Card 1 -->
+          <!-- Small Video Card 2 -->
           <article class="video-card video-card-small">
             <div class="video-thumbnail video-thumbnail-16-9">
               <iframe 
                 src="https://www.youtube.com/embed/u8GkvQAnM_o" 
-                title="Developer Tutorial: Getting Started"
+                title="Using Claude Code with Sourcegraph's MCP server"
                 frameborder="0" 
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
                 allowfullscreen
@@ -526,7 +544,7 @@
             </div>
           </article>
 
-          <!-- Small Video Card 2 -->
+          <!-- Small Video Card 3 -->
           <article class="video-card video-card-small">
             <div class="video-thumbnail video-thumbnail-16-9">
               <iframe 
@@ -543,30 +561,28 @@
               <h3 class="video-card-title">Getting started with Amp's TypeScript SDK</h3>
             </div>
           </article>
-
-          <!-- Small Video Card 3 -->
-          <article class="video-card video-card-small">
-            <div class="video-thumbnail video-thumbnail-16-9">
-              <iframe 
-                src="https://www.youtube.com/embed/xu3X6G7m-1Q" 
-                title="Using oracle with Amp"
-                frameborder="0" 
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
-                allowfullscreen
-                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
-              </iframe>
-            </div>
-            <div class="video-info">
-              <span class="video-category">Deep Dives / Demos</span>
-              <h3 class="video-card-title">Using "oracle" with Amp</h3>
-            </div>
-          </article>
         </div>
         
         <!-- More Videos Section -->
         <div class="more-section" id="more-videos" style="display: none;">
           <div class="video-grid">
             <!-- Archived videos appear here -->
+            <article class="video-card video-card-small">
+              <div class="video-thumbnail video-thumbnail-16-9">
+                <iframe 
+                  src="https://www.youtube.com/embed/xu3X6G7m-1Q" 
+                  title="Using &quot;oracle&quot; with Amp"
+                  frameborder="0" 
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+                  allowfullscreen
+                  style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+                </iframe>
+              </div>
+              <div class="video-info">
+                <span class="video-category">Deep Dives / Demos</span>
+                <h3 class="video-card-title">Using "oracle" with Amp</h3>
+              </div>
+            </article>
             <article class="video-card video-card-small">
               <div class="video-thumbnail video-thumbnail-16-9">
                 <iframe 


### PR DESCRIPTION
## Summary
Add new featured video and update documentation for Cloudflare Pages deployment.

## Changes
- Add "Why GitHub Code Search Fails at Enterprise Scale" video as Horizontal Card 1
- Cascade all existing videos down one position (oldest moved to More section)
- Add Deployment section to README documenting Cloudflare Pages hosting
- Update file structure in README to reflect `wrangler.jsonc` config

Made with [Cursor](https://cursor.com)