### PR TITLE
feat: add mole CLI portfolio video

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ _site
 .DS_Store
 node_modules/
 .tmp/
+
+# Editor / local tooling
+.cursor/
+.entire/

--- a/index.html
+++ b/index.html
@@ -646,6 +646,24 @@
           <article class="video-card video-card-horizontal">
             <div class="video-thumbnail video-thumbnail-16-9">
               <iframe 
+                src="https://www.youtube.com/embed/1NjIyrpg93o" 
+                title="Find gigabytes of hidden junk on your Mac with the mole CLI"
+                frameborder="0" 
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+                allowfullscreen
+                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+              </iframe>
+            </div>
+            <div class="video-info">
+              <span class="video-category">Deep Dives / Demos</span>
+              <h3 class="video-card-title">Find gigabytes of hidden junk on your Mac with the mole CLI</h3>
+            </div>
+          </article>
+
+          <!-- Horizontal Video Card 2 -->
+          <article class="video-card video-card-horizontal">
+            <div class="video-thumbnail video-thumbnail-16-9">
+              <iframe 
                 src="https://www.youtube.com/embed/g8BwfSed-8w" 
                 title="Sourcegraph Deep Search Updates (April 2026)"
                 frameborder="0" 
@@ -660,8 +678,8 @@
             </div>
           </article>
 
-          <!-- Horizontal Video Card 2 -->
-          <article class="video-card video-card-horizontal">
+          <!-- Small Video Card 1 -->
+          <article class="video-card video-card-small">
             <div class="video-thumbnail video-thumbnail-16-9">
               <iframe 
                 src="https://www.youtube.com/embed/ho4g5NQ5sXk" 
@@ -678,7 +696,7 @@
             </div>
           </article>
 
-          <!-- Small Video Card 1 -->
+          <!-- Small Video Card 2 -->
           <article class="video-card video-card-small">
             <div class="video-thumbnail video-thumbnail-16-9">
               <iframe 
@@ -696,7 +714,7 @@
             </div>
           </article>
 
-          <!-- Small Video Card 2 -->
+          <!-- Small Video Card 3 -->
           <article class="video-card video-card-small">
             <div class="video-thumbnail video-thumbnail-16-9">
               <iframe 
@@ -713,30 +731,28 @@
               <h3 class="video-card-title">Monitoring Critical Code Changes from AI Agents</h3>
             </div>
           </article>
-
-          <!-- Small Video Card 3 -->
-          <article class="video-card video-card-small">
-            <div class="video-thumbnail video-thumbnail-16-9">
-              <iframe 
-                src="https://www.youtube.com/embed/_OyUNs258mE" 
-                title="Why GitHub Code Search Fails at Enterprise Scale"
-                frameborder="0" 
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
-                allowfullscreen
-                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
-              </iframe>
-            </div>
-            <div class="video-info">
-              <span class="video-category">Deep Dives / Demos</span>
-              <h3 class="video-card-title">Why GitHub Code Search Fails at Enterprise Scale</h3>
-            </div>
-          </article>
         </div>
         
         <!-- More Videos Section -->
         <div class="more-section" id="more-videos" style="display: none;">
           <div class="video-grid">
             <!-- Archived videos appear here -->
+            <article class="video-card video-card-small">
+              <div class="video-thumbnail video-thumbnail-16-9">
+                <iframe 
+                  src="https://www.youtube.com/embed/_OyUNs258mE" 
+                  title="Why GitHub Code Search Fails at Enterprise Scale"
+                  frameborder="0" 
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+                  allowfullscreen
+                  style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+                </iframe>
+              </div>
+              <div class="video-info">
+                <span class="video-category">Deep Dives / Demos</span>
+                <h3 class="video-card-title">Why GitHub Code Search Fails at Enterprise Scale</h3>
+              </div>
+            </article>
             <article class="video-card video-card-small">
               <div class="video-thumbnail video-thumbnail-16-9">
                 <iframe 


### PR DESCRIPTION
## Summary

- Feature the mole CLI Mac demo as Horizontal Video Card 1 (YouTube `1NjIyrpg93o`).
- Cascade existing featured videos down the grid so prior spots stay in order.
- Move the former Small Card 3 (GitHub Code Search enterprise) to the top of the More section.

## Test plan

- Run `npx live-server` and open the home page; confirm the top two horizontal embeds and three small cards load.
- Expand More videos and confirm the enterprise GitHub comparison video appears first in the archived list.

Made with [Cursor](https://cursor.com)