### PR TITLE
feat: manage portfolio videos via videos.json

### DIFF
--- a/.cursor/skills/add-video/SKILL.md
+++ b/.cursor/skills/add-video/SKILL.md
@@ -1,133 +1,39 @@
 ---
 name: add-video
-description: Add a new YouTube video to the portfolio. New video becomes Horizontal Video Card 1, all other videos shift down, oldest goes to More section. Use when user types /add-video followed by a YouTube URL.
+description: Add a new YouTube video to the portfolio. New video becomes Horizontal Video Card 1, all others shift down, oldest goes to More section. Use when user types /add-video followed by a YouTube URL.
 ---
 
 # Add Video to Portfolio
 
-When user types `/add-video <URL>`, follow these steps exactly.
+When the user types `/add-video <URL>` (optional quoted title and category), run the add script from the repo root. Do **not** edit video HTML in `index.html` by hand.
 
-## Step 1: Extract Video ID
+## Command
 
-From the URL, extract the video ID:
-- `youtube.com/watch?v=VIDEO_ID` → use VIDEO_ID
-- `youtu.be/VIDEO_ID` → use VIDEO_ID
-- `youtube.com/embed/VIDEO_ID` → use VIDEO_ID
-
-## Step 2: Fetch Video Title
-
-Use the YouTube oEmbed API to get the video title (no API key needed):
-
-```
-https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v={VIDEO_ID}&format=json
+```bash
+node scripts/add-video.mjs "<URL>" ["Custom Title"] ["Category Name"]
 ```
 
-Fetch this URL and extract the `title` field from the JSON response. Use this title for:
-- The iframe `title` attribute
-- The `<h3 class="video-card-title">` text
+- URL: any YouTube format (`watch?v=`, `youtu.be/`, `embed/`)
+- Title: fetched from YouTube oEmbed unless overridden
+- Category: defaults to `Deep Dives / Demos` unless overridden
 
-If the fetch fails, fall back to "Video" as the default title.
+## On success
 
-## Step 3: Read index.html
+Confirm the video title and that it is now **Horizontal Video Card 1** (featured). Mention `/git` if the user wants to commit and open a PR.
 
-Read `index.html` and identify these 5 video cards by their HTML comments:
-- `<!-- Horizontal Video Card 1 -->` - first large video
-- `<!-- Horizontal Video Card 2 -->` - second large video
-- `<!-- Small Video Card 1 -->` - first small video
-- `<!-- Small Video Card 2 -->` - second small video
-- `<!-- Small Video Card 3 -->` - third small video
+## On failure
 
-Also find `<!-- More Videos Section -->` where archived videos go.
+Report the script error (stderr). Do not fall back to manual HTML edits.
 
-## Step 4: Cascade Videos Down
+## Data source
 
-Perform these moves in order:
+Videos are stored newest-first in `data/videos.json`. The script updates JSON and regenerates the marked section in `index.html` via `scripts/render-videos.mjs`.
 
-1. **Small Card 3 → More section**: Copy the entire `<article>` from Small Card 3 and insert it at the START of the More section's `<div class="video-grid">`, right after the `<!-- Archived videos appear here -->` comment (push existing archived videos down).
+## Rotation (unchanged)
 
-2. **Small Card 2 → Small Card 3**: Replace Small Card 3's `<article>` content with Small Card 2's content. Keep the `<!-- Small Video Card 3 -->` comment.
-
-3. **Small Card 1 → Small Card 2**: Replace Small Card 2's `<article>` content with Small Card 1's content. Keep the `<!-- Small Video Card 2 -->` comment.
-
-4. **Horizontal Card 2 → Small Card 1**: Replace Small Card 1's `<article>` with Horizontal Card 2's content, but change the class from `video-card-horizontal` to `video-card-small`. Keep the `<!-- Small Video Card 1 -->` comment.
-
-5. **Horizontal Card 1 → Horizontal Card 2**: Replace Horizontal Card 2's `<article>` content with Horizontal Card 1's content. Keep the `<!-- Horizontal Video Card 2 -->` comment.
-
-6. **New video → Horizontal Card 1**: Update Horizontal Card 1 with the new video:
-   - Set iframe src to `https://www.youtube.com/embed/{VIDEO_ID}`
-   - Set iframe title to the fetched YouTube title (from Step 2)
-   - Set `<h3 class="video-card-title">` to the fetched YouTube title
-   - Keep category as "Deep Dives / Demos" unless specified
-
-## Video Card Templates
-
-**Horizontal card (for positions 1-2):**
-```html
-          <!-- Horizontal Video Card 1 -->
-          <article class="video-card video-card-horizontal">
-            <div class="video-thumbnail video-thumbnail-16-9">
-              <iframe 
-                src="https://www.youtube.com/embed/{VIDEO_ID}" 
-                title="{TITLE}"
-                frameborder="0" 
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
-                allowfullscreen
-                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
-              </iframe>
-            </div>
-            <div class="video-info">
-              <span class="video-category">{CATEGORY}</span>
-              <h3 class="video-card-title">{TITLE}</h3>
-            </div>
-          </article>
-```
-
-**Small card (for positions 1-3 and More section):**
-```html
-          <!-- Small Video Card 1 -->
-          <article class="video-card video-card-small">
-            <div class="video-thumbnail video-thumbnail-16-9">
-              <iframe 
-                src="https://www.youtube.com/embed/{VIDEO_ID}" 
-                title="{TITLE}"
-                frameborder="0" 
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
-                allowfullscreen
-                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
-              </iframe>
-            </div>
-            <div class="video-info">
-              <span class="video-category">{CATEGORY}</span>
-              <h3 class="video-card-title">{TITLE}</h3>
-            </div>
-          </article>
-```
-
-## Example
-
-Input: `/add-video https://www.youtube.com/watch?v=abc123`
-
-Before:
-- Horizontal 1: Video A
-- Horizontal 2: Video B
-- Small 1: Video C
-- Small 2: Video D
-- Small 3: Video E
-- More: [Video F, Video G...]
-
-After:
-- Horizontal 1: **NEW VIDEO** (abc123)
-- Horizontal 2: Video A
-- Small 1: Video B (changed from horizontal to small class)
-- Small 2: Video C
-- Small 3: Video D
-- More: [Video E, Video F, Video G...]
-
-## Optional Title/Category Override
-
-By default, the video title is fetched automatically from YouTube.
-
-If user wants to override the title: `/add-video URL "My Custom Title"`
-If user wants to override title and category: `/add-video URL "My Custom Title" "Category Name"`
-
-User-provided values take precedence over the fetched YouTube title. Default category is "Deep Dives / Demos".
+| Position | Role |
+|----------|------|
+| JSON index 0 | Horizontal Card 1 (new video) |
+| 1 | Horizontal Card 2 |
+| 2–4 | Small Cards 1–3 |
+| 5+ | More section (archived) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,11 @@
 
 ### Local server
 Always use `npx live-server` to serve the site locally
+
+## Portfolio videos
+
+- **Source of truth:** `data/videos.json` (newest-first array of `{ id, title, category }`)
+- **Add a video:** `node scripts/add-video.mjs "<youtube-url>" ["Title"] ["Category"]` — or user command `/add-video <URL>`
+- **Re-render only:** `node scripts/render-videos.mjs` after editing `videos.json`
+- **Do not** edit the generated block between `<!-- VIDEOS:START -->` and `<!-- VIDEOS:END -->` in `index.html` by hand
+- Shorts carousel remains hand-edited in `index.html` (`/add-short` skill)

--- a/README.md
+++ b/README.md
@@ -33,11 +33,16 @@ Automatically adds a new YouTube video to the portfolio with proper rotation.
 ```
 
 **What it does:**
-1. Extracts the video ID from any YouTube URL format
-2. Fetches the video title automatically via YouTube's oEmbed API
-3. Places the new video as Horizontal Card 1 (featured position)
-4. Cascades all existing videos down one position
-5. Moves the oldest video (Small Card 3) to the "More" section
+1. Runs `node scripts/add-video.mjs` with your URL
+2. Extracts the video ID and fetches the title via YouTube's oEmbed API
+3. Prepends the video to `data/videos.json` (newest first)
+4. Regenerates the video section in `index.html` (Horizontal Card 1 featured; oldest archived to More)
+
+**Manual CLI (same as the agent runs):**
+```bash
+node scripts/add-video.mjs "https://www.youtube.com/watch?v=abc123"
+node scripts/render-videos.mjs   # re-render only, after editing data/videos.json
+```
 
 **Optional overrides:**
 ```
@@ -115,9 +120,14 @@ npx live-server
 
 ```
 ├── index.html                      # Main portfolio page
+├── data/
+│   └── videos.json                 # Long-form videos (newest first); source of truth
 ├── resume.html                     # Resume page
 ├── man.html                        # Man page style resume
 ├── scripts/
+│   ├── add-video.mjs               # Add video + render index.html
+│   ├── render-videos.mjs           # Regenerate video HTML from videos.json
+│   ├── migrate-videos-to-json.mjs  # One-time HTML → JSON migration
 │   └── generate-resume-pdf.sh      # Generates resume.pdf from resume.html
 ├── wrangler.jsonc                  # Cloudflare Pages deployment config
 ├── AGENTS.md                       # AI agent instructions

--- a/data/videos.json
+++ b/data/videos.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "DuJKS0-sS8U",
+    "title": "Connecting goose AI agent to Sourcegraph Deep Search via MCP",
+    "category": "Deep Dives / Demos"
+  },
+  {
     "id": "1NjIyrpg93o",
     "title": "Find gigabytes of hidden junk on your Mac with the mole CLI",
     "category": "Deep Dives / Demos"

--- a/data/videos.json
+++ b/data/videos.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "1NjIyrpg93o",
+    "title": "Find gigabytes of hidden junk on your Mac with the mole CLI",
+    "category": "Deep Dives / Demos"
+  },
+  {
+    "id": "g8BwfSed-8w",
+    "title": "Sourcegraph Deep Search Updates (April 2026)",
+    "category": "Deep Dives / Demos"
+  },
+  {
+    "id": "ho4g5NQ5sXk",
+    "title": "Find reusable code with Sourcegraph Deep Search",
+    "category": "Deep Dives / Demos"
+  },
+  {
+    "id": "hztOVXnoIm4",
+    "title": "How to Setup Sourcegraph's MCP Server with Windsurf",
+    "category": "Deep Dives / Demos"
+  },
+  {
+    "id": "Xj-2rg3WDh4",
+    "title": "Monitoring Critical Code Changes from AI Agents",
+    "category": "Deep Dives / Demos"
+  },
+  {
+    "id": "_OyUNs258mE",
+    "title": "Why GitHub Code Search Fails at Enterprise Scale",
+    "category": "Deep Dives / Demos"
+  },
+  {
+    "id": "PaoF-qnI2HE",
+    "title": "GitHub Code Search vs Sourcegraph - Quick Comparison 2026",
+    "category": "Deep Dives / Demos"
+  },
+  {
+    "id": "yeNZ-hIicgI",
+    "title": "Sourcegraph Deep Search for Slack: Query Your Codebase with Natural Language",
+    "category": "Deep Dives / Demos"
+  },
+  {
+    "id": "u8GkvQAnM_o",
+    "title": "Using Claude Code with Sourcegraph's MCP server",
+    "category": "Deep Dives / Demos"
+  },
+  {
+    "id": "aGNUR8b2gFo",
+    "title": "Getting started with Amp's TypeScript SDK",
+    "category": "Deep Dives / Demos"
+  },
+  {
+    "id": "xu3X6G7m-1Q",
+    "title": "Using \"oracle\" with Amp",
+    "category": "Deep Dives / Demos"
+  },
+  {
+    "id": "NNEegjonjMs",
+    "title": "Meet Sourcegraph Deep Search",
+    "category": "Deep Dives / Demos"
+  }
+]

--- a/index.html
+++ b/index.html
@@ -647,6 +647,23 @@
           <article class="video-card video-card-horizontal">
             <div class="video-thumbnail video-thumbnail-16-9">
               <iframe 
+                src="https://www.youtube.com/embed/DuJKS0-sS8U" 
+                title="Connecting goose AI agent to Sourcegraph Deep Search via MCP"
+                frameborder="0" 
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+                allowfullscreen
+                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+              </iframe>
+            </div>
+            <div class="video-info">
+              <span class="video-category">Deep Dives / Demos</span>
+              <h3 class="video-card-title">Connecting goose AI agent to Sourcegraph Deep Search via MCP</h3>
+            </div>
+          </article>
+          <!-- Horizontal Video Card 2 -->
+          <article class="video-card video-card-horizontal">
+            <div class="video-thumbnail video-thumbnail-16-9">
+              <iframe 
                 src="https://www.youtube.com/embed/1NjIyrpg93o" 
                 title="Find gigabytes of hidden junk on your Mac with the mole CLI"
                 frameborder="0" 
@@ -660,8 +677,8 @@
               <h3 class="video-card-title">Find gigabytes of hidden junk on your Mac with the mole CLI</h3>
             </div>
           </article>
-          <!-- Horizontal Video Card 2 -->
-          <article class="video-card video-card-horizontal">
+          <!-- Small Video Card 1 -->
+          <article class="video-card video-card-small">
             <div class="video-thumbnail video-thumbnail-16-9">
               <iframe 
                 src="https://www.youtube.com/embed/g8BwfSed-8w" 
@@ -677,7 +694,7 @@
               <h3 class="video-card-title">Sourcegraph Deep Search Updates (April 2026)</h3>
             </div>
           </article>
-          <!-- Small Video Card 1 -->
+          <!-- Small Video Card 2 -->
           <article class="video-card video-card-small">
             <div class="video-thumbnail video-thumbnail-16-9">
               <iframe 
@@ -694,7 +711,7 @@
               <h3 class="video-card-title">Find reusable code with Sourcegraph Deep Search</h3>
             </div>
           </article>
-          <!-- Small Video Card 2 -->
+          <!-- Small Video Card 3 -->
           <article class="video-card video-card-small">
             <div class="video-thumbnail video-thumbnail-16-9">
               <iframe 
@@ -711,29 +728,28 @@
               <h3 class="video-card-title">How to Setup Sourcegraph's MCP Server with Windsurf</h3>
             </div>
           </article>
-          <!-- Small Video Card 3 -->
-          <article class="video-card video-card-small">
-            <div class="video-thumbnail video-thumbnail-16-9">
-              <iframe 
-                src="https://www.youtube.com/embed/Xj-2rg3WDh4" 
-                title="Monitoring Critical Code Changes from AI Agents"
-                frameborder="0" 
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
-                allowfullscreen
-                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
-              </iframe>
-            </div>
-            <div class="video-info">
-              <span class="video-category">Deep Dives / Demos</span>
-              <h3 class="video-card-title">Monitoring Critical Code Changes from AI Agents</h3>
-            </div>
-          </article>
         </div>
 
         <!-- More Videos Section -->
         <div class="more-section" id="more-videos" style="display: none;">
           <div class="video-grid">
             <!-- Archived videos appear here -->
+            <article class="video-card video-card-small">
+              <div class="video-thumbnail video-thumbnail-16-9">
+                <iframe 
+                  src="https://www.youtube.com/embed/Xj-2rg3WDh4" 
+                  title="Monitoring Critical Code Changes from AI Agents"
+                  frameborder="0" 
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+                  allowfullscreen
+                  style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+                </iframe>
+              </div>
+              <div class="video-info">
+                <span class="video-category">Deep Dives / Demos</span>
+                <h3 class="video-card-title">Monitoring Critical Code Changes from AI Agents</h3>
+              </div>
+            </article>
             <article class="video-card video-card-small">
               <div class="video-thumbnail video-thumbnail-16-9">
                 <iframe 

--- a/index.html
+++ b/index.html
@@ -642,6 +642,7 @@
             </div>
           </div>
 
+          <!-- VIDEOS:START -->
           <!-- Horizontal Video Card 1 -->
           <article class="video-card video-card-horizontal">
             <div class="video-thumbnail video-thumbnail-16-9">
@@ -659,7 +660,6 @@
               <h3 class="video-card-title">Find gigabytes of hidden junk on your Mac with the mole CLI</h3>
             </div>
           </article>
-
           <!-- Horizontal Video Card 2 -->
           <article class="video-card video-card-horizontal">
             <div class="video-thumbnail video-thumbnail-16-9">
@@ -677,7 +677,6 @@
               <h3 class="video-card-title">Sourcegraph Deep Search Updates (April 2026)</h3>
             </div>
           </article>
-
           <!-- Small Video Card 1 -->
           <article class="video-card video-card-small">
             <div class="video-thumbnail video-thumbnail-16-9">
@@ -695,7 +694,6 @@
               <h3 class="video-card-title">Find reusable code with Sourcegraph Deep Search</h3>
             </div>
           </article>
-
           <!-- Small Video Card 2 -->
           <article class="video-card video-card-small">
             <div class="video-thumbnail video-thumbnail-16-9">
@@ -713,7 +711,6 @@
               <h3 class="video-card-title">How to Setup Sourcegraph's MCP Server with Windsurf</h3>
             </div>
           </article>
-
           <!-- Small Video Card 3 -->
           <article class="video-card video-card-small">
             <div class="video-thumbnail video-thumbnail-16-9">
@@ -732,7 +729,7 @@
             </div>
           </article>
         </div>
-        
+
         <!-- More Videos Section -->
         <div class="more-section" id="more-videos" style="display: none;">
           <div class="video-grid">
@@ -830,7 +827,7 @@
               </div>
               <div class="video-info">
                 <span class="video-category">Deep Dives / Demos</span>
-                <h3 class="video-card-title">Using "oracle" with Amp</h3>
+                <h3 class="video-card-title">Using &quot;oracle&quot; with Amp</h3>
               </div>
             </article>
             <article class="video-card video-card-small">
@@ -851,6 +848,7 @@
             </article>
           </div>
         </div>
+          <!-- VIDEOS:END -->
         
         <button class="btn btn-outline more-toggle" onclick="toggleMore()" style="margin-top: 2rem;">
           More

--- a/scripts/add-video.mjs
+++ b/scripts/add-video.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import {
+  DEFAULT_CATEGORY,
+  extractVideoId,
+  fetchYouTubeTitle,
+  readVideos,
+  updateIndexHtml,
+  writeVideos,
+} from './video-lib.mjs';
+
+async function main() {
+  const url = process.argv[2];
+  const titleOverride = process.argv[3];
+  const categoryOverride = process.argv[4];
+
+  if (!url) {
+    console.error('Usage: node scripts/add-video.mjs <youtube-url> ["Custom Title"] ["Category Name"]');
+    process.exit(1);
+  }
+
+  const id = extractVideoId(url);
+  const videos = readVideos();
+
+  if (videos.some((video) => video.id === id)) {
+    console.error(`Video ${id} is already in data/videos.json`);
+    process.exit(1);
+  }
+
+  let title = titleOverride;
+  if (!title) {
+    try {
+      title = await fetchYouTubeTitle(id);
+    } catch {
+      title = 'Video';
+    }
+  }
+
+  const category = categoryOverride || DEFAULT_CATEGORY;
+  const entry = { id, title, category };
+
+  videos.unshift(entry);
+  writeVideos(videos);
+  updateIndexHtml();
+
+  console.log(`Added: ${title}`);
+  console.log(`ID: ${id}`);
+  console.log('Position: Horizontal Video Card 1 (featured)');
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/migrate-videos-to-json.mjs
+++ b/scripts/migrate-videos-to-json.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * One-time migration: extract long-form videos from index.html into data/videos.json.
+ * Skips shorts carousel; reads featured + archived articles in DOM order.
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { INDEX_HTML, VIDEOS_JSON, writeVideos } from './video-lib.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function decodeHtmlEntities(text) {
+  return text
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
+function parseVideosFromHtml(html) {
+  const start = html.indexOf('<!-- Horizontal Video Card 1 -->');
+  const moreButton = html.indexOf('<button class="btn btn-outline more-toggle"');
+  const block = html.slice(start, moreButton);
+
+  const articleRegex =
+    /<article class="video-card[^"]*">[\s\S]*?embed\/([^"?]+)[\s\S]*?title="([^"]*)"[\s\S]*?video-category">([^<]*)<\/span>[\s\S]*?video-card-title">([^<]*)<\/h3>/g;
+
+  const videos = [];
+  let match;
+
+  while ((match = articleRegex.exec(block)) !== null) {
+    videos.push({
+      id: match[1],
+      title: decodeHtmlEntities(match[4].trim() || match[2]),
+      category: match[3].trim(),
+    });
+  }
+
+  return videos;
+}
+
+function main() {
+  const html = fs.readFileSync(INDEX_HTML, 'utf8');
+  const videos = parseVideosFromHtml(html);
+
+  if (videos.length === 0) {
+    console.error('No videos found. Check index.html structure.');
+    process.exit(1);
+  }
+
+  writeVideos(videos);
+  console.log(`Wrote ${videos.length} videos to ${path.relative(path.resolve(__dirname, '..'), VIDEOS_JSON)}`);
+}
+
+main();

--- a/scripts/render-videos.mjs
+++ b/scripts/render-videos.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import { updateIndexHtml } from './video-lib.mjs';
+
+updateIndexHtml();
+console.log('Rendered videos section into index.html');

--- a/scripts/video-lib.mjs
+++ b/scripts/video-lib.mjs
@@ -1,0 +1,141 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const ROOT = path.resolve(__dirname, '..');
+export const VIDEOS_JSON = path.join(ROOT, 'data', 'videos.json');
+export const INDEX_HTML = path.join(ROOT, 'index.html');
+export const START_MARKER = '<!-- VIDEOS:START -->';
+export const END_MARKER = '<!-- VIDEOS:END -->';
+export const DEFAULT_CATEGORY = 'Deep Dives / Demos';
+
+const IFRAME_ALLOW =
+  'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
+
+export function escapeHtml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export function readVideos() {
+  const raw = fs.readFileSync(VIDEOS_JSON, 'utf8');
+  return JSON.parse(raw);
+}
+
+export function writeVideos(videos) {
+  fs.writeFileSync(VIDEOS_JSON, JSON.stringify(videos, null, 2) + '\n');
+}
+
+export function extractVideoId(url) {
+  const patterns = [
+    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/,
+    /youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = url.match(pattern);
+    if (match) return match[1];
+  }
+
+  throw new Error(`Could not extract video ID from URL: ${url}`);
+}
+
+export async function fetchYouTubeTitle(videoId) {
+  const oembedUrl = `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoId}&format=json`;
+  const response = await fetch(oembedUrl);
+
+  if (!response.ok) {
+    throw new Error(`oEmbed request failed (${response.status})`);
+  }
+
+  const data = await response.json();
+  return data.title;
+}
+
+function renderCard(video, size, comment, indent) {
+  const cardClass = size === 'horizontal' ? 'video-card-horizontal' : 'video-card-small';
+  const pad = ' '.repeat(indent);
+  const innerPad = pad + '  ';
+  const titleAttr = escapeHtml(video.title);
+  const commentLine = comment ? `${pad}<!-- ${comment} -->\n` : '';
+
+  return `${commentLine}${pad}<article class="video-card ${cardClass}">
+${innerPad}<div class="video-thumbnail video-thumbnail-16-9">
+${innerPad}  <iframe 
+${innerPad}    src="https://www.youtube.com/embed/${video.id}" 
+${innerPad}    title="${titleAttr}"
+${innerPad}    frameborder="0" 
+${innerPad}    allow="${IFRAME_ALLOW}" 
+${innerPad}    allowfullscreen
+${innerPad}    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+${innerPad}  </iframe>
+${innerPad}</div>
+${innerPad}<div class="video-info">
+${innerPad}  <span class="video-category">${escapeHtml(video.category)}</span>
+${innerPad}  <h3 class="video-card-title">${escapeHtml(video.title)}</h3>
+${innerPad}</div>
+${pad}</article>`;
+}
+
+export function renderVideosHtml(videos) {
+  const featured = videos.slice(0, 5);
+  const archived = videos.slice(5);
+  const lines = [];
+
+  const featuredComments = [
+    'Horizontal Video Card 1',
+    'Horizontal Video Card 2',
+    'Small Video Card 1',
+    'Small Video Card 2',
+    'Small Video Card 3',
+  ];
+  const featuredSizes = ['horizontal', 'horizontal', 'small', 'small', 'small'];
+
+  for (let i = 0; i < featured.length; i++) {
+    lines.push(
+      renderCard(featured[i], featuredSizes[i], featuredComments[i], 10)
+    );
+  }
+
+  lines.push('        </div>');
+  lines.push('');
+  lines.push('        <!-- More Videos Section -->');
+  lines.push(
+    '        <div class="more-section" id="more-videos" style="display: none;">'
+  );
+  lines.push('          <div class="video-grid">');
+  lines.push('            <!-- Archived videos appear here -->');
+
+  for (const video of archived) {
+    lines.push(renderCard(video, 'small', null, 12));
+  }
+
+  lines.push('          </div>');
+  lines.push('        </div>');
+
+  return lines.join('\n');
+}
+
+export function renderVideosSection() {
+  const videos = readVideos();
+  return `${START_MARKER}\n${renderVideosHtml(videos)}\n          ${END_MARKER}`;
+}
+
+export function updateIndexHtml() {
+  const html = fs.readFileSync(INDEX_HTML, 'utf8');
+  const startIdx = html.indexOf(START_MARKER);
+  const endIdx = html.indexOf(END_MARKER);
+
+  if (startIdx === -1 || endIdx === -1) {
+    throw new Error(`Markers not found in index.html. Expected ${START_MARKER} and ${END_MARKER}`);
+  }
+
+  const before = html.slice(0, startIdx);
+  const after = html.slice(endIdx + END_MARKER.length);
+  const section = renderVideosSection();
+  fs.writeFileSync(INDEX_HTML, before + section + after);
+}


### PR DESCRIPTION
## Summary
- Add `data/videos.json` as the source of truth for long-form portfolio videos (newest first).
- Add `scripts/add-video.mjs` and `scripts/render-videos.mjs` to prepend videos and regenerate the marked HTML block in `index.html`.
- Update `/add-video` skill, README, and AGENTS.md so agents run the script instead of manual HTML cascading.

## Test plan
- [x] Run `node scripts/add-video.mjs` with a new YouTube URL and confirm it appears as Horizontal Card 1
- [x] Run `node scripts/render-videos.mjs` after editing `data/videos.json` and confirm `index.html` updates
- [x] Open site with `npx live-server` and verify featured + More videos render correctly
- [x] Confirm duplicate video ID is rejected

Made with [Cursor](https://cursor.com)