### PR TITLE
chore: align Entire config and stop pushing checkpoints

### DIFF
--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,0 +1,4 @@
+tmp/
+settings.local.json
+metadata/
+logs/

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,0 +1,7 @@
+{
+  "enabled": true,
+  "telemetry": true,
+  "strategy_options": {
+    "push_sessions": false
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ node_modules/
 
 # Editor / local tooling
 .cursor/
-.entire/


### PR DESCRIPTION
## Summary

- Commit `.entire/settings.json` and `.entire/.gitignore` per [Entire docs](https://docs.entire.io/cli/configuration#project-and-local-files) instead of ignoring the whole `.entire/` directory.
- Set `push_sessions: false` so AI session checkpoints stay local on this public repo.

## Test plan

- [ ] Confirm `.entire/logs/` and `.entire/metadata/` are not tracked after merge
- [ ] Run `git push` on `main` and verify `entire/checkpoints/v1` is not pushed to origin
- [ ] Optional follow-up: delete remote `entire/checkpoints/v1` to remove previously pushed transcripts

Made with [Cursor](https://cursor.com)