### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,12 @@ Always use `npx live-server` to serve the site locally
 - **Re-render only:** `node scripts/render-videos.mjs` after editing `videos.json`
 - **Do not** edit the generated block between `<!-- VIDEOS:START -->` and `<!-- VIDEOS:END -->` in `index.html` by hand
 - Shorts carousel remains hand-edited in `index.html` (`/add-short` skill)
+
+## Cursor Cloud specific instructions
+
+This is a static site (no `package.json`/lockfile, no build step). Node and Chrome are pre-installed; `live-server` runs via `npx` (cached, no install needed).
+
+- **Run the site (dev):** `npx live-server --port=8080 --host=127.0.0.1 --no-browser` from the repo root, then open `http://127.0.0.1:8080/`. Serves `index.html`, `resume.html`, and `man.html`.
+- **Render videos:** `node scripts/render-videos.mjs` (or `node scripts/add-video.mjs <url>`) regenerates the block between `<!-- VIDEOS:START/END -->` in `index.html` from `data/videos.json`. `add-video.mjs` fetches the title from YouTube's oEmbed API (needs network); pass a title override as a second arg to skip that.
+- **Resume PDF:** `./scripts/generate-resume-pdf.sh` needs Chrome. The script only auto-detects macOS Chrome paths, so on this Linux VM you MUST set `CHROME_BIN=/usr/local/bin/google-chrome ./scripts/generate-resume-pdf.sh`. It reuses a live-server already running on `127.0.0.1:8080`, otherwise starts a temporary one on port 8765.
+- **Lint/tests:** none configured; validate by loading pages in the browser.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this static portfolio site, and documents non-obvious startup caveats for future cloud agents.

This is a static site with no `package.json`/lockfile and no build step. Node and Chrome are pre-installed on the VM; `live-server` runs via `npx` (cached).

## Changes

- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering how to run the dev server, render the videos section, and generate the resume PDF (notably that `CHROME_BIN=/usr/local/bin/google-chrome` is required on Linux).

## Verification

- `npx live-server --port=8080` serves `index.html`, `resume.html`, `man.html` (all HTTP 200).
- `node scripts/render-videos.mjs` runs clean and is idempotent (no diff).
- `CHROME_BIN=/usr/local/bin/google-chrome ./scripts/generate-resume-pdf.sh` produces a valid PDF.
- Browser walkthrough: loaded the portfolio, rendered video cards, clicked "More" to reveal archived videos, and loaded the resume page.

[portfolio_site_walkthrough.mp4](https://cursor.com/agents/bc-aa167b93-45d0-4252-8aaf-ef39fd705f9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_site_walkthrough.mp4)

[Portfolio hero](https://cursor.com/agents/bc-aa167b93-45d0-4252-8aaf-ef39fd705f9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_hero.webp)
[Expanded videos section](https://cursor.com/agents/bc-aa167b93-45d0-4252-8aaf-ef39fd705f9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_videos_expanded.webp)
[Resume page](https://cursor.com/agents/bc-aa167b93-45d0-4252-8aaf-ef39fd705f9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fresume_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa167b93-45d0-4252-8aaf-ef39fd705f9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa167b93-45d0-4252-8aaf-ef39fd705f9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

