### PR TITLE
Rename video category to Demos

### DIFF
--- a/.cursor/skills/add-video/SKILL.md
+++ b/.cursor/skills/add-video/SKILL.md
@@ -15,7 +15,7 @@ node scripts/add-video.mjs "<URL>" ["Custom Title"] ["Category Name"]
 
 - URL: any YouTube format (`watch?v=`, `youtu.be/`, `embed/`)
 - Title: fetched from YouTube oEmbed unless overridden
-- Category: defaults to `Deep Dives / Demos` unless overridden
+- Category: defaults to `Demos` unless overridden
 
 ## On success
 

--- a/data/videos.json
+++ b/data/videos.json
@@ -2,81 +2,81 @@
   {
     "id": "VR74iU4mpg0",
     "title": "Sourcegraph Changelog: Code Finder and Compare Page (July 2026)",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "8g8q8pRPCms",
     "title": "Agentic Batch Changes Beta for migrations, security patching, and dependency updates",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "79Yj-_juLY4",
     "title": "Make GitHub Copilot Smarter Across All Your Repositories with Deep Search MCP Server",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "DuJKS0-sS8U",
     "title": "Connecting goose AI agent to Sourcegraph Deep Search via MCP",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "1NjIyrpg93o",
     "title": "Find gigabytes of hidden junk on your Mac with the mole CLI",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "g8BwfSed-8w",
     "title": "Sourcegraph Deep Search Updates (April 2026)",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "ho4g5NQ5sXk",
     "title": "Find reusable code with Sourcegraph Deep Search",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "hztOVXnoIm4",
     "title": "How to Setup Sourcegraph's MCP Server with Windsurf",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "Xj-2rg3WDh4",
     "title": "Monitoring Critical Code Changes from AI Agents",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "_OyUNs258mE",
     "title": "Why GitHub Code Search Fails at Enterprise Scale",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "PaoF-qnI2HE",
     "title": "GitHub Code Search vs Sourcegraph - Quick Comparison 2026",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "yeNZ-hIicgI",
     "title": "Sourcegraph Deep Search for Slack: Query Your Codebase with Natural Language",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "u8GkvQAnM_o",
     "title": "Using Claude Code with Sourcegraph's MCP server",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "aGNUR8b2gFo",
     "title": "Getting started with Amp's TypeScript SDK",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "xu3X6G7m-1Q",
     "title": "Using \"oracle\" with Amp",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   },
   {
     "id": "NNEegjonjMs",
     "title": "Meet Sourcegraph Deep Search",
-    "category": "Deep Dives / Demos"
+    "category": "Demos"
   }
 ]

--- a/index.html
+++ b/index.html
@@ -638,7 +638,7 @@
               </iframe>
             </div>
             <div class="video-info">
-              <span class="video-category">Deep Dives / Demos</span>
+              <span class="video-category">Demos</span>
               <h3 class="video-card-title">Sourcegraph Changelog: Code Finder and Compare Page (July 2026)</h3>
             </div>
           </article>
@@ -655,7 +655,7 @@
               </iframe>
             </div>
             <div class="video-info">
-              <span class="video-category">Deep Dives / Demos</span>
+              <span class="video-category">Demos</span>
               <h3 class="video-card-title">Agentic Batch Changes Beta for migrations, security patching, and dependency updates</h3>
             </div>
           </article>
@@ -672,7 +672,7 @@
               </iframe>
             </div>
             <div class="video-info">
-              <span class="video-category">Deep Dives / Demos</span>
+              <span class="video-category">Demos</span>
               <h3 class="video-card-title">Make GitHub Copilot Smarter Across All Your Repositories with Deep Search MCP Server</h3>
             </div>
           </article>
@@ -689,7 +689,7 @@
               </iframe>
             </div>
             <div class="video-info">
-              <span class="video-category">Deep Dives / Demos</span>
+              <span class="video-category">Demos</span>
               <h3 class="video-card-title">Connecting goose AI agent to Sourcegraph Deep Search via MCP</h3>
             </div>
           </article>
@@ -706,7 +706,7 @@
               </iframe>
             </div>
             <div class="video-info">
-              <span class="video-category">Deep Dives / Demos</span>
+              <span class="video-category">Demos</span>
               <h3 class="video-card-title">Find gigabytes of hidden junk on your Mac with the mole CLI</h3>
             </div>
           </article>
@@ -728,7 +728,7 @@
                 </iframe>
               </div>
               <div class="video-info">
-                <span class="video-category">Deep Dives / Demos</span>
+                <span class="video-category">Demos</span>
                 <h3 class="video-card-title">Sourcegraph Deep Search Updates (April 2026)</h3>
               </div>
             </article>
@@ -744,7 +744,7 @@
                 </iframe>
               </div>
               <div class="video-info">
-                <span class="video-category">Deep Dives / Demos</span>
+                <span class="video-category">Demos</span>
                 <h3 class="video-card-title">Find reusable code with Sourcegraph Deep Search</h3>
               </div>
             </article>
@@ -760,7 +760,7 @@
                 </iframe>
               </div>
               <div class="video-info">
-                <span class="video-category">Deep Dives / Demos</span>
+                <span class="video-category">Demos</span>
                 <h3 class="video-card-title">How to Setup Sourcegraph's MCP Server with Windsurf</h3>
               </div>
             </article>
@@ -776,7 +776,7 @@
                 </iframe>
               </div>
               <div class="video-info">
-                <span class="video-category">Deep Dives / Demos</span>
+                <span class="video-category">Demos</span>
                 <h3 class="video-card-title">Monitoring Critical Code Changes from AI Agents</h3>
               </div>
             </article>
@@ -792,7 +792,7 @@
                 </iframe>
               </div>
               <div class="video-info">
-                <span class="video-category">Deep Dives / Demos</span>
+                <span class="video-category">Demos</span>
                 <h3 class="video-card-title">Why GitHub Code Search Fails at Enterprise Scale</h3>
               </div>
             </article>
@@ -808,7 +808,7 @@
                 </iframe>
               </div>
               <div class="video-info">
-                <span class="video-category">Deep Dives / Demos</span>
+                <span class="video-category">Demos</span>
                 <h3 class="video-card-title">GitHub Code Search vs Sourcegraph - Quick Comparison 2026</h3>
               </div>
             </article>
@@ -824,7 +824,7 @@
                 </iframe>
               </div>
               <div class="video-info">
-                <span class="video-category">Deep Dives / Demos</span>
+                <span class="video-category">Demos</span>
                 <h3 class="video-card-title">Sourcegraph Deep Search for Slack: Query Your Codebase with Natural Language</h3>
               </div>
             </article>
@@ -840,7 +840,7 @@
                 </iframe>
               </div>
               <div class="video-info">
-                <span class="video-category">Deep Dives / Demos</span>
+                <span class="video-category">Demos</span>
                 <h3 class="video-card-title">Using Claude Code with Sourcegraph's MCP server</h3>
               </div>
             </article>
@@ -856,7 +856,7 @@
                 </iframe>
               </div>
               <div class="video-info">
-                <span class="video-category">Deep Dives / Demos</span>
+                <span class="video-category">Demos</span>
                 <h3 class="video-card-title">Getting started with Amp's TypeScript SDK</h3>
               </div>
             </article>
@@ -872,7 +872,7 @@
                 </iframe>
               </div>
               <div class="video-info">
-                <span class="video-category">Deep Dives / Demos</span>
+                <span class="video-category">Demos</span>
                 <h3 class="video-card-title">Using &quot;oracle&quot; with Amp</h3>
               </div>
             </article>
@@ -888,7 +888,7 @@
                 </iframe>
               </div>
               <div class="video-info">
-                <span class="video-category">Deep Dives / Demos</span>
+                <span class="video-category">Demos</span>
                 <h3 class="video-card-title">Meet Sourcegraph Deep Search</h3>
               </div>
             </article>

--- a/scripts/video-lib.mjs
+++ b/scripts/video-lib.mjs
@@ -8,7 +8,7 @@ export const VIDEOS_JSON = path.join(ROOT, 'data', 'videos.json');
 export const INDEX_HTML = path.join(ROOT, 'index.html');
 export const START_MARKER = '<!-- VIDEOS:START -->';
 export const END_MARKER = '<!-- VIDEOS:END -->';
-export const DEFAULT_CATEGORY = 'Deep Dives / Demos';
+export const DEFAULT_CATEGORY = 'Demos';
 
 const IFRAME_ALLOW =
   'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Renames the portfolio video category from `Deep Dives / Demos` to `Demos` across `data/videos.json` and the regenerated cards in `index.html`
- Updates the add-video default category so new videos use `Demos`

## Test plan
- [ ] Open the site and confirm each horizontal/small/more video card shows `DEMOS` (not `DEEP DIVES / DEMOS`)
- [ ] Confirm Shorts cards still show `Shorts / Social`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e6adfae-270e-4d07-8f0a-8ca2285f215c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e6adfae-270e-4d07-8f0a-8ca2285f215c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

