### PR TITLE
feat: add /start-local-server skill

### DIFF
--- a/.cursor/skills/start-local-server/SKILL.md
+++ b/.cursor/skills/start-local-server/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: start-local-server
+description: Start the local preview server for this static site with npx live-server on port 8080. Use when the user types /start-local-server, asks to preview the site locally, or hits ERR_CONNECTION_REFUSED on 127.0.0.1:8080.
+---
+
+# Start Local Server
+
+When the user types `/start-local-server`, serve the repo root with `npx live-server`.
+
+## Command
+
+From the repository root:
+
+```bash
+npx --yes live-server --port=8080 --host=127.0.0.1 --no-browser
+```
+
+## Steps
+
+1. Check whether something is already serving `http://127.0.0.1:8080/`:
+   - `curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/`
+   - If you get `200`, report that the server is already running and stop.
+2. Otherwise start `live-server` in the background (do not open a browser).
+3. Wait until the process prints `Ready for changes` (or equivalent) and confirm with a `200` from curl.
+4. Tell the user the site is available at **http://127.0.0.1:8080/**
+
+## Notes
+
+- Always use `npx live-server` (see `AGENTS.md`). Do not switch to Python `http.server`, Vite, or another static server unless the user asks.
+- Bind to `127.0.0.1:8080` so local browser previews and resume PDF generation stay consistent.
+- Keep the server running after starting it; do not kill an existing healthy instance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Memory
 
 ## Build/Test Commands
-- Preview site locally: Not configured (standard web files only)
+- Preview site locally: `npx --yes live-server --port=8080 --host=127.0.0.1 --no-browser` — or user command `/start-local-server`
 - Validation: Check HTML validity with W3C validator
 
 ## Code Style Guidelines
@@ -29,7 +29,7 @@
 - Dark mode only (do not add light-mode / prefers-color-scheme overrides)
 
 ### Local server
-Always use `npx live-server` to serve the site locally
+Always use `npx live-server` to serve the site locally (`/start-local-server` skill)
 
 ## Portfolio videos
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a `/start-local-server` Cursor skill that starts `npx live-server` on `127.0.0.1:8080`
- Updates `AGENTS.md` so local preview docs point at the same command and skill

Rebased onto `main` after #73 merged.

## Test plan
- [x] Confirm `.cursor/skills/start-local-server/SKILL.md` is present and tracked
- [x] Trigger `/start-local-server` and verify the site loads at http://127.0.0.1:8080/
- [x] Re-run the skill while the server is already up and confirm it reports already running
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f56d21e-d02c-41dd-a3ba-5f6c998f18b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f56d21e-d02c-41dd-a3ba-5f6c998f18b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

